### PR TITLE
Add suport for Pebble round (Chalk)

### DIFF
--- a/pebble/appinfo.json
+++ b/pebble/appinfo.json
@@ -37,5 +37,11 @@
         "file": "fonts/Roboto-Condensed.ttf"
       }
     ]
-  }
+  },
+  "targetPlatforms": [
+    "aplite",
+    "basalt",
+    "chalk"
+  ],
+  "sdkVersion": "3"
 }

--- a/pebble/src/geocaching.c
+++ b/pebble/src/geocaching.c
@@ -303,7 +303,6 @@ void handle_init(void) {
 
   window_set_background_color(window, GColorBlack);
 
-  window_set_fullscreen(window, true);
   window_stack_push(window, true);
 
   Layer *window_layer = window_get_root_layer(window);

--- a/pebble/src/geocaching.c
+++ b/pebble/src/geocaching.c
@@ -305,7 +305,13 @@ void handle_init(void) {
 
   window_stack_push(window, true);
 
+#if defined(PBL_RECT)
   Layer *window_layer = window_get_root_layer(window);
+#elif defined(PBL_ROUND)
+  Layer *window_container = window_get_root_layer(window);
+  Layer *window_layer = layer_create(GRect(18, 6, 144, 168));
+  layer_add_child(window_container, window_layer);
+#endif
 
   // Initialize distance layout
   Layer *distance_holder = layer_create(GRect(0, 80, 144, 40));

--- a/pebble/wscript
+++ b/pebble/wscript
@@ -5,6 +5,8 @@
 # Feel free to customize this to your needs.
 #
 
+import os.path
+
 top = '.'
 out = 'build'
 
@@ -17,8 +19,23 @@ def configure(ctx):
 def build(ctx):
     ctx.load('pebble_sdk')
 
-    ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
-                    target='pebble-app.elf')
+    build_worker = os.path.exists('worker_src')
+    binaries = []
 
-    ctx.pbl_bundle(elf='pebble-app.elf',
-                   js=ctx.path.ant_glob('src/js/**/*.js'))
+    for p in ctx.env.TARGET_PLATFORMS:
+        ctx.set_env(ctx.all_envs[p])
+        ctx.set_group(ctx.env.PLATFORM_NAME)
+        app_elf='{}/pebble-app.elf'.format(ctx.env.BUILD_DIR)
+        ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
+        target=app_elf)
+
+        if build_worker:
+            worker_elf='{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
+            binaries.append({'platform': p, 'app_elf': app_elf, 'worker_elf': worker_elf})
+            ctx.pbl_worker(source=ctx.path.ant_glob('worker_src/**/*.c'),
+            target=worker_elf)
+        else:
+            binaries.append({'platform': p, 'app_elf': app_elf})
+
+    ctx.set_group('bundle')
+    ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob('src/js/**/*.js'))


### PR DESCRIPTION
The Pebble Round has a different size and shape of display compared to the original Pebble and the Pebble Time, and isn't suited to the current UI design as the date/time line gets truncated at both ends by the Round's circular display.

New UI for Round:
![pebble_screenshot_2016-01-26_17-57-42](https://cloud.githubusercontent.com/assets/8430262/12727221/d53b0e86-c913-11e5-93c7-43564a51f272.png)
